### PR TITLE
fix: dashboard activity & plugins

### DIFF
--- a/themes/theme.css
+++ b/themes/theme.css
@@ -276,6 +276,7 @@ html {
 .upNextContainer,
 .osdTextContainer, .osdTimeText,
 .selectionCommandsPanel > button:hover > .material-icons,
+.paperListLabel,
 legend {
   color: var(--main-text);
 }
@@ -324,7 +325,8 @@ div[role=presentation].jstree-wholerow-clicked {
 }
 
 .iconOsd,
-.cardContent.defaultCardBackground {
+.cardContent.defaultCardBackground,
+.cardContent .defaultCardBackground {
   background-color: var(--second-background);
 }
 
@@ -413,7 +415,12 @@ div[role=presentation].jstree-wholerow-clicked {
   background-color: var(--second-background) !important;
 }
 
-.programCell:focus {
+div[data-role="controlgroup"] .emby-button {
+  color: var(--main-text) !important;
+  background-color: var(--second-background) !important;
+}
+
+.programCell:focus, div[data-role="controlgroup"] a.ui-btn-active {
   color: var(--main-background) !important;
   background-color: var(--main-color) !important;
 }


### PR DESCRIPTION
Closes #27

- Fixes background color of cards:

| Before | After |
|--------|--------|
| <img width="308" height="229" alt="image" src="https://github.com/user-attachments/assets/51cf9ed8-0f7f-4f88-8524-f31aba95a34f" /> | <img width="313" height="234" alt="image" src="https://github.com/user-attachments/assets/7309a841-7b6d-4a8f-9424-9714b880835b" /> | 

- Fixes color of tabs in user edit page:

| Before | After |
|--------|--------|
| <img width="398" height="115" alt="image" src="https://github.com/user-attachments/assets/53d6bc2e-2cfb-4f7c-80ef-179bf8ce9455" /> | <img width="393" height="112" alt="image" src="https://github.com/user-attachments/assets/22f038a4-984b-4439-9e92-b57fa9e4cafc" /> | 