### PR TITLE
fix: incorrect color of player overlay buttons in catppuccin latte

### DIFF
--- a/jellyfin.tera
+++ b/jellyfin.tera
@@ -30,4 +30,6 @@ whiskers:
   --dimmer-text: #{{overlay2.hex}};
   --green-color: var(--green);
   --red-color: var(--red);
+  --white-text: {% if flavor.identifier == "latte" %}#{{base.hex}}{% else %}#{{text.hex}}{% endif %};
+  --dark-background: {% if flavor.identifier == "latte" %}#{{text.hex}}{% else %}#{{mantle.hex}}{% endif %};
 }

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -23,4 +23,6 @@
   --dimmer-text: #949cbb;
   --green-color: var(--green);
   --red-color: var(--red);
+  --white-text: #c6d0f5;
+  --dark-background: #292c3c;
 }

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -23,4 +23,6 @@
   --dimmer-text: #7c7f93;
   --green-color: var(--green);
   --red-color: var(--red);
+  --white-text: #eff1f5;
+  --dark-background: #4c4f69;
 }

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -23,4 +23,6 @@
   --dimmer-text: #939ab7;
   --green-color: var(--green);
   --red-color: var(--red);
+  --white-text: #cad3f5;
+  --dark-background: #1e2030;
 }

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -23,4 +23,6 @@
   --dimmer-text: #9399b2;
   --green-color: var(--green);
   --red-color: var(--red);
+  --white-text: #cdd6f4;
+  --dark-background: #181825;
 }

--- a/themes/theme.css
+++ b/themes/theme.css
@@ -189,9 +189,6 @@ html {
 .listItemButton,
 .checkboxListLabel,
 .lnkMediaFolder,
-.sessionAppName,
-.sessionNowPlayingInfo,
-.sessionNowPlayingTime,
 .MuiTypography-root {
   color: var(--main-text) !important;
 }
@@ -274,11 +271,25 @@ html {
 .emby-button-foreground,
 .iconOsd .iconOsdIcon,
 .upNextContainer,
-.osdTextContainer, .osdTimeText,
 .selectionCommandsPanel > button:hover > .material-icons,
 .paperListLabel,
 legend {
   color: var(--main-text);
+}
+
+.osdTextContainer, .osdTimeText,
+.transparentDocument .paper-icon-button-light,
+.transparentDocument .pageTitle,
+.cardOverlayContainer .paper-icon-button-light,
+.sessionAppName,
+.sessionNowPlayingInfo,
+.sessionNowPlayingTime {
+  color: var(--white-text);
+}
+
+.devicesList .cardContent.defaultCardBackground,
+.cardContent.defaultCardBackground:has(.sessionNowPlayingContent) {
+  background-color: var(--dark-background) !important;
 }
 
 .fieldDescription,
@@ -293,9 +304,7 @@ legend {
 }
 
 .selectionCommandsPanel > button > .material-icons,
-.checkboxOutline .checkboxIcon-checked,
-.sessionAppName,
-.sessionNowPlayingInfo {
+.checkboxOutline .checkboxIcon-checked {
   color: var(--main-background);
 }
 


### PR DESCRIPTION
Fixes the color of player overlay buttons in Latte flavor.

| Before | After |
|--------|--------|
| <img width="334" height="242" alt="image" src="https://github.com/user-attachments/assets/b083a7d1-87d2-48d6-9f61-51c06ed3b857" /> | <img width="338" height="250" alt="image" src="https://github.com/user-attachments/assets/42eb4c0e-f4e3-49aa-a0d5-b122c5ff7048" /> | 
| <img width="1855" height="959" alt="image" src="https://github.com/user-attachments/assets/dd3cc16a-c904-47ff-b723-44cba6a880c7" /> | <img width="1855" height="959" alt="image" src="https://github.com/user-attachments/assets/07666ed0-c3a3-4940-8ef5-a8119a8d9253" /> |