### PR TITLE
fix: incorrect background color of media details

### DIFF
--- a/themes/theme.css
+++ b/themes/theme.css
@@ -36,7 +36,6 @@
 
 .backgroundContainer,
 .formDialogHeader,
-.detailRibbon,
 .dialog,
 .dashboardGeneralForm,
 html {
@@ -64,6 +63,10 @@ html {
 .cardBox,
 .paperList {
   background: var(--main-background);
+}
+
+.noBackdropTransparency .detailPagePrimaryContainer {
+  background: var(--second-background);
 }
 
 .playstatebutton-icon-played,
@@ -347,7 +350,7 @@ div[role=presentation].jstree-wholerow-clicked {
   background-color: var(--hover-background) !important;
 }
 
-.detailPagePrimaryContainer,
+.detailRibbon,
 .backgroundContainer.withBackdrop {
   background-color: var(--main-background-transparent);
 }


### PR DESCRIPTION
Closes #32

| Before | After |
|--------|--------|
| <img width="1853" height="962" alt="Screenshot 2025-10-20 at 21-17-28" src="https://github.com/user-attachments/assets/cc7013a0-001a-428f-a044-4af2706b2f3a" /> | <img width="1853" height="962" alt="Screenshot 2025-10-20 at 21-16-37" src="https://github.com/user-attachments/assets/ec3f04c0-c5d4-472d-9747-7870876be5b3" /> | 

> [!NOTE]
> The dashboard and metadata manager are still unthemed as these pages don't apply custom CSS in the new client.