### PR TITLE
fix: alphaPickerButton colors

### DIFF
--- a/themes/theme.css
+++ b/themes/theme.css
@@ -237,6 +237,10 @@ html {
   color: var(--dimmer-text);
 }
 
+.alphaPickerButton {
+  color: var(--hover-background);
+}
+
 .buttonActive,
 .button-accent-flat,
 .metadataSidebarIcon,
@@ -305,6 +309,7 @@ legend {
 .fieldDescription,
 .MuiListItemText-secondary,
 .MuiListSubheader-root,
+.alphaPickerButton-selected,
 .secondary {
   color: var(--dimmer-text) !important;
 }


### PR DESCRIPTION
| before | after |
|-|-|
| <img width="37" height="165" alt="before" src="https://github.com/user-attachments/assets/25683fcc-d219-4921-9373-920b7c624a80" /> | <img width="43" height="180" alt="after" src="https://github.com/user-attachments/assets/559c2fbc-8c67-4352-a39e-9b1a182a804b" /> |